### PR TITLE
feat: optimize formatSQLInString to support some features at the same…

### DIFF
--- a/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
+++ b/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
@@ -44,12 +44,22 @@ object SQLFormatterPlugin extends AutoPlugin {
   }
 
   def formatSQLInString(content: String): String = {
-    val sqlPattern = """spark\.sql\(\n?\s*s?\"\"\"(?s)(.*?)\"\"\"\.stripMargin\)""".r
-    sqlPattern.replaceAllIn(content, m => {
-      val sql = m.group(1)
-      val formattedSQL = formatSQLString(sql)
-      s"""spark.sql(s\"\"\"$formattedSQL\"\"\".stripMargin)"""
-    })
+    val sqlPattern = """\"{1,3}(?si)(.*?select.*?)\"{1,3}""".r
+    val sections: Array[String] = content.split("=")
+    println(sections.toList)
+    val strBuilder: StringBuilder = new StringBuilder
+    for (section <- sections) {
+      val newSection: String = sqlPattern.replaceAllIn(
+        section,
+        m => {
+          val sql = m.group(1)
+          val formattedSQL = formatSQLString(sql)
+          s"""\"\"\"$formattedSQL\"\"\".stripMargin"""
+        }
+      )
+      strBuilder.append(newSection + "=")
+    }
+    strBuilder.toString().dropRight(1)
   }
 
   def formatSQLString(sql: String): String = {

--- a/src/test/scala/org/coins/sql/format/SQLFormatterPluginSpec.scala
+++ b/src/test/scala/org/coins/sql/format/SQLFormatterPluginSpec.scala
@@ -115,7 +115,7 @@ ${customLeftIndent}  FROM people"""
    * 2. Support both three double quotes or a single double quote wrapped sql statement.
    * 3. Support comments
    */
-  "formatSQLInString debug" should "print in console" in {
+  "formatSQLInString" should "support situations as comments mentioned" in {
     val threeDoubleQuotes = "\"\"\""
     val content =
       s"""package xx.xx.xx


### PR DESCRIPTION
`formatSQLInString` needs to implement the following features at the same time：
   1. none sql string should not be affected.
   2. Support both three double quotes or a single double quote wrapped sql statement.
   3. Support comments