### PR TITLE
feat: optimize formatSQLInString to support some features at the same…

### DIFF
--- a/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
+++ b/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
@@ -45,15 +45,22 @@ object SQLFormatterPlugin extends AutoPlugin {
   }
 
   def formatSQLInString(content: String): String = {
-    val sqlPattern = """spark\.sql\(\n?\s*s?\"\"\"(?s)(.*?)\"\"\"\.stripMargin\)""".r
-    sqlPattern.replaceAllIn(
-      content,
-      m => {
-        val sql = m.group(1)
-        val formattedSQL = formatSQLString(sql)
-        s"""spark.sql(s\"\"\"$formattedSQL\"\"\".stripMargin)"""
-      }
-    )
+    val sqlPattern = """\"{1,3}(?si)(.*?select.*?)\"{1,3}""".r
+    val sections: Array[String] = content.split("=")
+    println(sections.toList)
+    val strBuilder: StringBuilder = new StringBuilder
+    for (section <- sections) {
+      val newSection: String = sqlPattern.replaceAllIn(
+        section,
+        m => {
+          val sql = m.group(1)
+          val formattedSQL = formatSQLString(sql)
+          s"""\"\"\"$formattedSQL\"\"\".stripMargin"""
+        }
+      )
+      strBuilder.append(newSection + "=")
+    }
+    strBuilder.toString().dropRight(1)
   }
 
   def formatSQLString(sql: String): String = {

--- a/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
+++ b/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
@@ -45,22 +45,15 @@ object SQLFormatterPlugin extends AutoPlugin {
   }
 
   def formatSQLInString(content: String): String = {
-    val sqlPattern = """\"{1,3}(?si)(.*?select.*?)\"{1,3}""".r
-    val sections: Array[String] = content.split("=")
-    println(sections.toList)
-    val strBuilder: StringBuilder = new StringBuilder
-    for (section <- sections) {
-      val newSection: String = sqlPattern.replaceAllIn(
-        section,
-        m => {
-          val sql = m.group(1)
-          val formattedSQL = formatSQLString(sql)
-          s"""\"\"\"$formattedSQL\"\"\".stripMargin"""
-        }
-      )
-      strBuilder.append(newSection + "=")
-    }
-    strBuilder.toString().dropRight(1)
+    val sqlPattern = """\"{1,3}(?si)([^"]*?select[^"]*?)\"{1,3}""".r
+    sqlPattern.replaceAllIn(
+      content,
+      m => {
+        val sql = m.group(1)
+        val formattedSQL = formatSQLString(sql)
+        s"""\"\"\"$formattedSQL\"\"\".stripMargin"""
+      }
+    )
   }
 
   def formatSQLString(sql: String): String = {

--- a/src/test/scala/org/coins/sql/format/SQLFormatterPluginSpec.scala
+++ b/src/test/scala/org/coins/sql/format/SQLFormatterPluginSpec.scala
@@ -1,6 +1,7 @@
 package org.coins.sql.format
 
 import org.scalatest.flatspec.{AnyFlatSpec => FlatSpec}
+import org.coins.sql.format.SQLFormatterPlugin.formatSQLInString
 import org.scalatest.matchers.should.Matchers
 import scala.util.Random
 
@@ -106,5 +107,48 @@ ${customLeftIndent}  FROM people"""
     val actualFormattedString = SQLFormatterPlugin.formatSQLString(inputSQL)
 
     actualFormattedString shouldBe expectedSQl
+  }
+
+  /** `formatSQLInString` needs to implement the following features at the same time：
+    *   1. none sql string should not be affected.
+    *   2. Support both three double quotes or a single double quote wrapped sql statement.
+    */
+  "formatSQLInString" should "support situations as comments mentioned" in {
+    val threeDoubleQuotes = "\"\"\""
+    val content =
+      s"""package xx.xx.xx
+         |object xxxJob {
+         |  private class SparkJob(deltaService: DeltaService)(implicit spark: SparkSession) {
+         |    val str = "string should not be impacted"
+         |    val sql1 = "  select * from user"
+         |    spark.sql("select * from user")
+         |    spark.sql($threeDoubleQuotes select * from user$threeDoubleQuotes)
+         |    val sql2 = $threeDoubleQuotes
+         |                 |-- this is a comment
+         |                 |select * from people$threeDoubleQuotes
+         |  }
+         |}""".stripMargin
+    val actualFormattedContent: String = formatSQLInString(content)
+
+    val expectedString = s"""package xx.xx.xx
+                            |object xxxJob {
+                            |  private class SparkJob(deltaService: DeltaService)(implicit spark: SparkSession) {
+                            |    val str = "string should not be impacted"
+                            |    val sql1 = $threeDoubleQuotes
+                            |        |SELECT *
+                            |        |  FROM user$threeDoubleQuotes.stripMargin
+                            |    spark.sql($threeDoubleQuotes
+                            |        |SELECT *
+                            |        |  FROM user$threeDoubleQuotes.stripMargin)
+                            |    spark.sql($threeDoubleQuotes
+                            |        |SELECT *
+                            |        |  FROM user$threeDoubleQuotes.stripMargin)
+                            |    val sql2 = $threeDoubleQuotes-- this is a comment
+                            |                 |SELECT *
+                            |                 |  FROM people$threeDoubleQuotes.stripMargin
+                            |  }
+                            |}""".stripMargin
+
+    actualFormattedContent shouldBe expectedString
   }
 }


### PR DESCRIPTION
`formatSQLInString` needs to implement the following features at the same time
1. none sql string should not be affected.
2. Support both three double quotes or a single double quote wrapped sql statement.