### PR TITLE
fix: support to return well formatted SQL when refer to variables in sql with '$'

### DIFF
--- a/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
+++ b/src/main/scala/org/coins/sql/format/SQLFormatterPlugin.scala
@@ -3,7 +3,10 @@ package org.coins.sql.format
 import sbt.Keys._
 import sbt._
 
-object SQLFormatterPlugin extends AutoPlugin {
+import java.time.Instant
+import java.util.UUID
+
+object SQLFormatterPlugin extends AutoPlugin with SQLFormatterPluginTrait {
 
   object autoImport {
     val formatSQL =
@@ -44,7 +47,7 @@ object SQLFormatterPlugin extends AutoPlugin {
     log.info(s"Formatted SQL in $file")
   }
 
-  def formatSQLInString(content: String): String = {
+  override def formatSQLInString(content: String): String = {
     val sqlPattern = """\"{1,3}(?si)([^"]*?select[^"]*?)\"{1,3}""".r
     sqlPattern.replaceAllIn(
       content,

--- a/src/main/scala/org/coins/sql/format/SQLFormatterPluginDeco.scala
+++ b/src/main/scala/org/coins/sql/format/SQLFormatterPluginDeco.scala
@@ -1,0 +1,19 @@
+package org.coins.sql.format
+
+import org.coins.sql.format.SQLFormatterPlugin.{formatSQLInString => fmtSQLString}
+
+import java.time.Instant
+import java.util.UUID
+
+object SQLFormatterPluginDeco extends SQLFormatterPluginTrait {
+  private def dollarSignReplacement(): String = {
+    val uuid = UUID.randomUUID
+    val timestamp = Instant.now().toEpochMilli
+    "#" + timestamp.toString + uuid + "#"
+  }
+  override def formatSQLInString(content: String): String = {
+    val replacement = dollarSignReplacement()
+    val tmpContent: String = content.replace("$", replacement)
+    fmtSQLString(tmpContent).replace(replacement, "$")
+  }
+}

--- a/src/main/scala/org/coins/sql/format/SQLFormatterPluginTrait.scala
+++ b/src/main/scala/org/coins/sql/format/SQLFormatterPluginTrait.scala
@@ -1,0 +1,5 @@
+package org.coins.sql.format
+
+trait SQLFormatterPluginTrait {
+  def formatSQLInString(content: String): String
+}

--- a/src/test/scala/org/coins/sql/format/SQLFormatterPluginSpec.scala
+++ b/src/test/scala/org/coins/sql/format/SQLFormatterPluginSpec.scala
@@ -153,7 +153,7 @@ ${customLeftIndent}  FROM people"""
     actualFormattedContent shouldBe expectedString
   }
 
-  "formatSQLInString" should "support to return well formatted SQL when refer to variables in sql with `$` " in {
+  "formatSQLInString" should "support to return well formatted SQL when refer to variables in sql with `$`" in {
     val threeDoubleQuotes = "\"\"\""
     val dollarSign = "$"
     val content =


### PR DESCRIPTION
The pr makes the following changes
- fix #22 